### PR TITLE
adds target resolever and data download to target page

### DIFF
--- a/src/components/AladinLite.vue
+++ b/src/components/AladinLite.vue
@@ -8,8 +8,8 @@ import A from 'aladin-lite'
 
 // define which properties are passed in from the parent, i.e. ":xxx"
 const props = defineProps<{
-    ra: string,
-    dec: string
+    ra: number,
+    dec: number
 }>()
 
 let aladin = null

--- a/src/components/DataDownload.vue
+++ b/src/components/DataDownload.vue
@@ -1,0 +1,131 @@
+<template>
+    <v-menu location="bottom">
+      <template v-slot:activator="{ props }">
+        <v-btn color="secondary-darken-1" rounded="0" class="my-0" v-bind="props"
+         v-tippy="'Download data files for this target'">
+          Download Data
+          <v-icon right>mdi-menu-down</v-icon>
+        </v-btn>
+      </template>
+
+      <!-- <v-list variant="tonal">
+        <v-list-item @click.stop="showDialog('http')">
+          <v-list-item-title>Raw Files (HTTP)</v-list-item-title>
+        </v-list-item>
+        <v-list-item @click.stop="showDialog('curl')">
+          <v-list-item-title>As a CURL Script</v-list-item-title>
+        </v-list-item>
+        <v-list-item @click.stop="showDialog('rsync')">
+          <v-list-item-title>As an RSYNC Script</v-list-item-title>
+        </v-list-item>
+        <v-list-item @click.stop="showDialog('python')">
+          <v-list-item-title>With Python Code</v-list-item-title>
+        </v-list-item>
+      </v-list> -->
+
+      <v-list variant="tonal">
+        <v-list-item v-for="(item, index) in dloptions" :key="index" @click.stop="showDialog(item.dialog, item.code)">
+          <v-list-item-title>{{item.title}}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+
+      <v-dialog v-model="dialog" max-width="800px">
+        <v-card>
+          <v-card-title>{{ dialogTitle }}</v-card-title>
+          <v-card-subtitle>Authentication setup may be needed</v-card-subtitle>
+          <v-card-text variant='tonal' style="overflow-x: auto;">
+            <pre><code>{{ codeSnippet }}</code></pre>
+          </v-card-text>
+          <v-card-actions>
+            <v-btn prepend-icon="mdi-content-copy" color="primary" @click="copyToClipboard(codeSnippet)">
+              <template v-slot:prepend>
+                <v-icon :color="copied ? 'success' : 'primary'" :icon="copied ? 'mdi-check' : 'mdi-content-copy'"></v-icon>
+                </template>
+              Copy to Clipboard</v-btn>
+            <v-spacer></v-spacer>
+            <v-btn prepend-icon='mdi-close' color="primary" @click="dialog = false">Close</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-menu>
+  </template>
+
+  <script setup lang="ts">
+  import { ref, defineProps } from 'vue';
+  import { useAppStore } from '@/store/app'
+
+const store = useAppStore()
+
+// define which properties are passed in from the parent, i.e. ":xxx"
+const props = defineProps<{
+    files: Array<string>
+}>()
+
+  const dialog = ref(false);
+  const dialogTitle = ref('')
+  const codeSnippet = ref('')
+  let copied = ref(false)
+
+  let dloptions = [
+    {key: 'http', title: 'With wget', value: 'http',
+    dialog: 'Download via Http', code: generateCode('http')},
+    {key: 'rsync', title: 'With rsync', value: 'rsync',
+    dialog: 'Download using Rsync', code: generateCode('rsync')},
+    {key: 'python', title: 'With Python', value: 'python',
+    dialog: "Download with sdss_access", code: generateCode('python')}
+  ]
+
+  function showDialog(title: string, code: string) {
+    copied.value = false
+    dialog.value = true;
+    dialogTitle.value = title;
+    codeSnippet.value = code;
+  }
+
+  function copyToClipboard(text: string) {
+  navigator.clipboard.writeText(text).then(() => {
+    console.log('Text copied to clipboard');
+    copied.value = true
+  }).catch(err => {
+    console.error('Failed to copy text: ', err);
+  })
+}
+
+function convertPath(path: string, key: string) {
+    const newPath = path.split("/sas/")[1]
+    const route = (path.includes('ipl') || path.includes('work')) ? 'sdss5' : 'sdss'
+    const user = (path.includes('ipl') || path.includes('work')) ? 'sdss5@' : ''
+
+    const base = (key == 'http') ? `https://data.${route}.org/sas/` : `rsync://${user}dtn.sdss.org/`
+    return `${base}${newPath}`
+}
+
+  function generateCode(key: string) {
+
+    let urls = props.files.map(x => convertPath(x, key))
+    urls.push(urls[0])
+    console.log('urls', urls)
+    let code = ''
+    switch (key) {
+      case 'http':
+        code = `wget ${urls.join(' ')}`
+        break
+      case 'rsync':
+        code = urls.map(x => `rsync -avz --no-motd ${x} .`).join(" \n")
+        break;
+      case 'python':
+        code = `
+          from sdss_access import Access
+          access = Access(release="${store.release}")
+          access.remote()
+          urls = ${JSON.stringify(urls)}
+          for url in urls:
+              access.add_file(url, input_type='url')
+          access.set_stream()
+          access.commit()`
+          break
+    }
+    return code
+  }
+
+</script>

--- a/src/components/TargetResolver.vue
+++ b/src/components/TargetResolver.vue
@@ -1,0 +1,70 @@
+<template>
+    <!-- Add the Resolve Target Button below the AladinLite component -->
+    <v-btn rounded="0" class='mt-2' color="primary-darken-1" @click="dialog = true" v-tippy="'Resolve target coordinates to within 3 arcmin using Simbad'">
+        Resolve Target
+    </v-btn>
+
+    <!-- v-dialog for showing the resolution results -->
+    <v-dialog v-model="dialog" scrollable width="auto">
+        <v-card>
+            <v-card-title>Resolved Targets</v-card-title>
+            <v-card-subtitle>within 3 arcmin</v-card-subtitle>
+            <v-card-text>
+                <v-data-table :headers="header" :items="results" :items-per-page="50"
+                >
+                <!-- make the main id a simbad anchor -->
+                <template v-slot:item.main_id="{ value }">
+                    <a :href="`https://simbad.u-strasbg.fr/simbad/sim-id?Ident=${value}&submit=submit+id`" target="_blank">{{ value }}</a>
+                </template>
+                </v-data-table>
+            </v-card-text>
+            <v-card-actions>
+                <v-btn prepend-icon='mdi-close' color="secondary" block @click="dialog = false">Close Dialog</v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script lang="ts" setup>
+
+import { ref, defineProps, watch} from 'vue'
+import axios from 'axios'
+
+// define which properties are passed in from the parent, i.e. ":xxx"
+const props = defineProps<{
+    ra: Number,
+    dec: Number
+}>()
+
+let dialog = ref(false)
+let header = ref([])
+let results = ref([])
+
+header.value = [
+    { title: "Main ID", key: "main_id" },
+    { title: "RA", key: "ra" },
+    { title: "Dec", key: "dec" },
+    { title: "Distance [arcsec]", key: "distance_result.value" },
+]
+
+async function fetchResolutionResults() {
+    // resolve the target coordinates using the valis endpoint
+    const url = import.meta.env.VITE_API_URL + `/target/resolve/coord?coord=${props.ra}&coord=${props.dec}&cunit=deg&radius=3&runit=arcmin`;
+
+    await axios.get(url)
+    .then((response) => {
+        results.value = response.data
+    })
+    .catch((error) => {
+        console.error("Axios fetch error: ", error);
+    })
+}
+
+// create watcher for the dialog
+watch(dialog, async (newVal) => {
+    // watch for dialog changes and send request
+    if (newVal) await fetchResolutionResults();
+})
+
+
+</script>

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -13,7 +13,12 @@
                     {{ formatNumber(metadata.ra_sdss_id, 5) }}, {{ formatNumber(metadata.dec_sdss_id, 5) }}
                 </p>
                 <v-skeleton-loader v-if="loading" type="card"></v-skeleton-loader>
-                <aladin-lite v-else :ra=metadata.ra_sdss_id :dec=metadata.dec_sdss_id></aladin-lite>
+                <aladin-lite v-else :ra="metadata.ra_sdss_id" :dec="metadata.dec_sdss_id"></aladin-lite>
+
+                <div class="d-flex flex-column">
+                    <target-resolver :ra="metadata.ra_sdss_id" :dec="metadata.dec_sdss_id"></target-resolver>
+                    <data-download :files="files"></data-download>
+                </div>
             </v-col>
             <v-col md="9">
                 <v-card>
@@ -99,6 +104,8 @@ import JSONbig from 'json-big'
 
 import Solara from '@/components/Solara.vue'
 import AladinLite from '@/components/AladinLite.vue'
+import TargetResolver from '@/components/TargetResolver.vue'
+import DataDownload from '@/components/DataDownload.vue'
 
 // get the application state store and router
 const store = useAppStore()
@@ -118,6 +125,7 @@ let cartSort = [{ key: 'run_on', order: 'desc' }]
 let panels = ref([0])
 let files = ref([])
 let has_files = ref(false)
+let dialog = ref(false)
 
 let head = [
     {key: 'catalogid', title: 'CatalogID'},


### PR DESCRIPTION
This PR adds a target resolver and data download component to the Target page.  It adds a new button that opens a dialog window which resolves the target coordinates with Simbad, and displays the results.  It also adds a button for data download options, giving the copy-paste commands to download the data with wget, rsync, or python.