### PR TITLE
Adds persistent store to pinia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "core-js": "^3.29.0",
         "json-big": "^1.0.2",
         "pinia": "^2.0.0",
+        "pinia-plugin-persistedstate": "^3.2.1",
         "roboto-fontface": "*",
         "vue": "^3.3.4",
         "vue-router": "^4.1.6",
@@ -4556,6 +4557,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pinia-plugin-persistedstate": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.2.1.tgz",
+      "integrity": "sha512-MK++8LRUsGF7r45PjBFES82ISnPzyO6IZx3CH5vyPseFLZCk1g2kgx6l/nW8pEBKxxd4do0P6bJw+mUSZIEZUQ==",
+      "peerDependencies": {
+        "pinia": "^2.0.0"
       }
     },
     "node_modules/pinia/node_modules/vue-demi": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "core-js": "^3.29.0",
     "json-big": "^1.0.2",
     "pinia": "^2.0.0",
+    "pinia-plugin-persistedstate": "^3.2.1",
     "roboto-fontface": "*",
     "vue": "^3.3.4",
     "vue-router": "^4.1.6",

--- a/src/components/ReleaseSelect.vue
+++ b/src/components/ReleaseSelect.vue
@@ -38,15 +38,22 @@ let required = [
                 ]
 
 async function get_releases() {
+    if (Object.keys(store.all_releases).length !== 0) {
+          console.log('releases already stored')
+          return
+      }
+
     // function to get the data release from Valis
     // using public = false and a hard-coded public release to get all releases
     await axios.get(import.meta.env.VITE_API_URL + '/envs/releases?public=False&release=DR17')
         .then((response) => {
             console.log('resp data', response.data)
             // remove the MPLs
-            let rels = response.data.filter((rel: string) => !rel.startsWith("M")).reverse()
+            let rels = response.data.filter((rel: string) => !rel.startsWith("M") && !rel.startsWith("W")).reverse()
             // remove the older DRs for now; update this to only DR19 once it's available
             rels = rels.filter((rel: string) => rel.startsWith("DR") ? parseInt(rel.slice(2)) >= 18 : rel)
+            // write code to filter out all IPL except IPL3 from rels
+            rels = rels.filter((rel: string) => rel.startsWith("IPL") ? rel.endsWith("3") : rel)
             // store the releases and check for selection
             store.all_releases = rels
             store.check_release()

--- a/src/components/ReleaseSelect.vue
+++ b/src/components/ReleaseSelect.vue
@@ -52,7 +52,7 @@ async function get_releases() {
             let rels = response.data.filter((rel: string) => !rel.startsWith("M") && !rel.startsWith("W")).reverse()
             // remove the older DRs for now; update this to only DR19 once it's available
             rels = rels.filter((rel: string) => rel.startsWith("DR") ? parseInt(rel.slice(2)) >= 18 : rel)
-            // write code to filter out all IPL except IPL3 from rels
+            // filter out all IPL except IPL3 from rels
             rels = rels.filter((rel: string) => rel.startsWith("IPL") ? rel.endsWith("3") : rel)
             // store the releases and check for selection
             store.all_releases = rels

--- a/src/components/ReleaseSelect.vue
+++ b/src/components/ReleaseSelect.vue
@@ -48,7 +48,7 @@ async function get_releases() {
     await axios.get(import.meta.env.VITE_API_URL + '/envs/releases?public=False&release=DR17')
         .then((response) => {
             console.log('resp data', response.data)
-            // remove the MPLs
+            // remove the MPLs and work release
             let rels = response.data.filter((rel: string) => !rel.startsWith("M") && !rel.startsWith("W")).reverse()
             // remove the older DRs for now; update this to only DR19 once it's available
             rels = rels.filter((rel: string) => rel.startsWith("DR") ? parseInt(rel.slice(2)) >= 18 : rel)

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -10,6 +10,10 @@ import vuetify from './vuetify'
 import pinia from '../store'
 import router from '../router'
 
+// Persisted State
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
+pinia.use(piniaPluginPersistedstate)
+
 // Types
 import type { App } from 'vue'
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -75,5 +75,20 @@ export const useAppStore = defineStore('app', {
       return this.logged_in || (!this.logged_in && this.release.startsWith("DR"))
     }
 
-  }
+  },
+  persist: {
+    enabled: true,
+    strategies: [
+      {
+        key: 'app-release',
+        storage: sessionStorage,
+        paths: ['release', 'all_releases'],
+      },
+      {
+        key: 'app-user',
+        storage: sessionStorage,
+        paths: ['user', 'auth', 'logged_in'],
+      }
+    ],
+  },
 })


### PR DESCRIPTION
This PR closes #15 .  It adds a persistent store to Pinia using the plugin, https://prazdevs.github.io/pinia-plugin-persistedstate/.   This allows to persist any values in the current store in either browser [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), or [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).  

For now, I'm only storing the selected release and user login information in `sessionStorage`.  It now persists when loading pages into new tabs, or when reloading tabs.  The sessionStorage is cleared when the page session ends.  