### PR TITLE
Adds option for theme toggling

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -55,6 +55,10 @@
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import ConeSearch from '@/components/ConeSearch.vue'
+import useStoredTheme from '@/composables/useTheme'
+
+// mount the stored theme
+useStoredTheme()
 
 const router = useRouter();
 const targetId = ref('');

--- a/src/components/Solara.vue
+++ b/src/components/Solara.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="valid" id="zora-solara">
-        <iframe id='iframe' :src=url width="100%" height="600px" title="Solara app running Jdaviz" frameborder="0"></iframe>
+        <iframe id='iframe' :src=url width="100%" height="600px" title="Solara app running Jdaviz" frameborder="0" ref="iframe"></iframe>
     </div>
     <v-banner v-else type="warning" class='ma-4' color="warning" lines="one" icon="mdi-emoticon-sad"><v-banner-text>{{ errmsg }}</v-banner-text></v-banner>
 </template>
@@ -8,7 +8,8 @@
 <script lang="ts" setup>
 
 import axios from 'axios'
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
+import { useTheme } from 'vuetify'
 
 
 // define which properties are passed in from the parent, i.e. ":xxx"
@@ -18,11 +19,13 @@ const props = defineProps<{
 }>()
 
 
+let iframe = ref(null)
 let valid = ref(false)
 let errmsg = ref('')
+let theme = useTheme()
 
 import.meta.env.VITE_API_URL + '/info/database'
-let url = ref(import.meta.env.VITE_API_URL + `/solara/embed/?release=IPL3&sdssid=${props.sdssid}&files=${props.files.join()}`)
+let url = ref(import.meta.env.VITE_API_URL + `/solara/embed/?release=IPL3&sdssid=${props.sdssid}&files=${props.files.join()}&theme=${theme.global.name.value}`)
 console.log('url', url)
 
 async function check_solara() {
@@ -42,6 +45,15 @@ async function check_solara() {
             }
         })
 }
+
+// create watcher for the theme
+watch(() => theme.global.name.value, (newVal) => {
+    console.log('theme change', newVal)
+    // watch for theme changes and send request
+    if (iframe.value && iframe.value.contentWindow) {
+        iframe.value.contentWindow.postMessage({type: 'themeChange', theme: newVal}, '*')
+    }
+})
 
 onMounted(() => {
     // check the solara server

--- a/src/composables/useTheme.js
+++ b/src/composables/useTheme.js
@@ -1,0 +1,17 @@
+import { onMounted } from 'vue'
+import { useTheme } from 'vuetify'
+import { useAppStore } from '@/store/app'
+
+export default function useStoredTheme() {
+  const theme = useTheme()
+  const store = useAppStore()
+
+  onMounted(() => {
+    const storedTheme = store.theme
+    if (storedTheme) {
+      theme.global.name.value = storedTheme
+    }
+  })
+
+  return theme
+}

--- a/src/layouts/default/AppBar.vue
+++ b/src/layouts/default/AppBar.vue
@@ -41,7 +41,7 @@
       </v-col>
 
       <!-- toggle theme -->
-      <!-- <v-btn @click="toggleTheme"><v-icon icon="mdi-theme-light-dark"/></v-btn> -->
+      <v-btn @click="toggleTheme" v-tippy="'Toggle Theme'"><v-icon icon="mdi-theme-light-dark"/></v-btn>
     </v-row>
   </v-app-bar>
 
@@ -110,6 +110,7 @@ const dataviewlink = { text: 'DataView', icon: 'mdi-chart-scatter-plot', site: '
 // function to toggle the dark/light theme
 function toggleTheme () {
   theme.global.name.value = theme.global.current.value.dark ? 'light' : 'dark'
+  store.theme = theme.global.name.value
 }
 
 const closeDrawerOnResize = () => {

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -13,7 +13,8 @@ export const useAppStore = defineStore('app', {
     programs: [],
     program_map: {},
     carton_map: {},
-    db_info: {}
+    db_info: {},
+    theme: '',
   }),
   actions: {
     get_releases() {
@@ -88,6 +89,11 @@ export const useAppStore = defineStore('app', {
         key: 'app-user',
         storage: sessionStorage,
         paths: ['user', 'auth', 'logged_in'],
+      },
+      {
+        key: 'app-theme',
+        storage: sessionStorage,
+        paths: ['theme']
       }
     ],
   },

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -57,6 +57,10 @@
 
 import { ref, watch, onMounted } from 'vue'
 import { useTheme } from 'vuetify'
+import useStoredTheme from '@/composables/useTheme'
+
+// mount the stored theme
+useStoredTheme()
 
 const theme = useTheme()
 

--- a/src/views/DataView.vue
+++ b/src/views/DataView.vue
@@ -3,7 +3,7 @@
         <v-col md="12">
             <v-banner v-if="store.release !== 'IPL3'" class='ma-4' color="error" lines="one" icon="mdi-emoticon-sad"><v-banner-text> The DataView dashboard is only available for IPL-3.</v-banner-text></v-banner>
             <div v-else id="solara-dataview">
-                <iframe id='iframe' :src="url" width="100%" height="1200px" title="Solara app running Explorer Dashboard" frameborder="0"></iframe>
+                <iframe id='iframe' :src="url" width="100%" height="1200px" title="Solara app running Explorer Dashboard" frameborder="0" ref="iframe"></iframe>
             </div>
         </v-col>
     </v-row>
@@ -11,12 +11,25 @@
 
 <script setup lang="ts">
 
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useAppStore } from '@/store/app'
+import useStoredTheme from '@/composables/useTheme'
+
+// mount the stored theme
+useStoredTheme()
 
 // get the application state store and router
 const store = useAppStore()
 
-let url = ref(import.meta.env.VITE_API_URL + '/solara/dashboard')
+let iframe = ref(null)
+let url = ref(import.meta.env.VITE_API_URL + `/solara/dashboard?theme=${store.theme}`)
+
+// create watcher for the theme
+watch(() => store.theme, (newVal) => {
+    // watch for theme changes and send request
+    if (iframe.value && iframe.value.contentWindow) {
+        iframe.value.contentWindow.postMessage({type: 'themeChange', theme: newVal}, '*')
+    }
+})
 
 </script>

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -4,6 +4,10 @@
 
 <script lang="ts" setup>
 import A from 'aladin-lite'
+import useStoredTheme from '@/composables/useTheme'
+
+// mount the stored theme
+useStoredTheme()
 
 let aladin = null
 
@@ -11,6 +15,58 @@ A.init.then(() => {
     aladin = A.aladin('#explore-aladin-lite', {target: 'M101', fov: 5, projection: "AIT",
     survey: "P/PanSTARRS/DR1/color-z-zg-g", cooFrame: 'ICRSd', showCooGridControl: true,
     showSimbadPointerControl: true, showCooGrid: true, showContextMenu: true});
+
+    let btn = A.button({
+                content: 'My button',
+                classList: ['myButton'],
+                tooltip: {cssStyle: {color: 'red'}, content: 'Create a moc in pink!', position: {direction: 'top'}},
+                action(o) {
+                    aladin.select('poly', p => {
+                        try {
+                            let ra = []
+                            let dec = []
+                            for (const v of p.vertices) {
+                                let [lon, lat] = aladin.pix2world(v.x, v.y);
+                                ra.push(lon)
+                                dec.push(lat)
+                            }
+                            let moc = A.MOCFromPolygon(
+                                {ra, dec},
+                                {name: 'poly', lineWidth: 3.0, color: 'pink'},
+                            );
+                            aladin.addMOC(moc)
+                        } catch(_) {
+                            alert('Selection covers a region out of the projection definition domain.');
+                        }
+                    })
+                }
+            });
+
+    let bbtn = A.button({
+        content: 'Test',
+        classList: ['testbutton'],
+        action(o) {
+            aladin.select('circle', p => {
+                let [lon, lat] = aladin.pix2world(p.x, p.y);
+                console.log(p, lon, lat);
+                var s = aladin.getSize();
+  	            var f = aladin.getFov();
+                console.log(s, f);
+                var c1 = f[0]/s[0];
+                var c2 = f[1]/s[1];
+  	            console.log('pixel scale [deg/pix]', c1, c2);
+                console.log(lon, lat, c1 * p.r)
+
+                var overlay = A.graphicOverlay({color: '#ee2345', lineWidth: 2});
+                aladin.addOverlay(overlay);
+                overlay.add(A.circle(lon, lat, c1 * p.r));
+            })
+        }
+
+    })
+
+    aladin.addUI(btn)
+    aladin.addUI(bbtn)
 });
 </script>
 

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -100,6 +100,10 @@
 <script setup lang="ts">
 import { useAppStore } from '@/store/app'
 import { ref, onMounted } from 'vue'
+import useStoredTheme from '@/composables/useTheme'
+
+// mount the stored theme
+useStoredTheme()
 
 // get the application state store and router
 const store = useAppStore()

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -86,10 +86,14 @@ import TextInput from '@/components/TextInput.vue'
 import DropdownSelect from '@/components/DropdownSelect.vue';
 import { useRouter } from 'vue-router';
 import { useAppStore } from '@/store/app'
+import useStoredTheme from '@/composables/useTheme'
 
 // get the application state store and router
 const store = useAppStore()
 const router = useRouter()
+
+// mount the stored theme
+useStoredTheme()
 
 // set up a form reference, is the name in v-form ref="form"
 let form = ref(null);
@@ -277,4 +281,3 @@ onMounted(() => {
 // }, { immediate: true, deep: true })
 
 </script>
-

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -106,10 +106,14 @@ import Solara from '@/components/Solara.vue'
 import AladinLite from '@/components/AladinLite.vue'
 import TargetResolver from '@/components/TargetResolver.vue'
 import DataDownload from '@/components/DataDownload.vue'
+import useStoredTheme from '@/composables/useTheme'
 
 // get the application state store and router
 const store = useAppStore()
 const route = useRoute()
+
+// mount the stored theme
+useStoredTheme()
 
 const sdss_id = route.params.sdss_id
 const missingId = !sdss_id


### PR DESCRIPTION
This PR closes #33.  It adds a new theme toggle button to the appbar.  It now stores the theme in the persistent store, so page loads into new tabs preserve the theme.  It moves the common theme mount to a new composable function, `useTheme`.  

It also pushes the theme into the Solara apps through an iframe postMessage, where it applies the theme change.   