### PR TITLE
Adds new observed field 

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -4,7 +4,7 @@ import JSONbig from 'json-big'
 // Defines the API instance in Axios with special handling for big integers.
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  timeout: 5000,
+  timeout: 60000,
   transformResponse: [
     function transform(data) {
       // Replacing the default transformResponse in axios because this uses JSON.parse and causes problems

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -91,6 +91,12 @@
                 </v-icon>
             </template>
 
+             <!-- add checkmark for has_been_observed boolean -->
+             <template v-slot:item.has_been_observed="{ item }">
+                <v-icon>
+                {{ item.has_been_observed ? "mdi-checkbox-marked" : null }}
+                </v-icon>
+            </template>
             </v-data-table>
         </v-col>
     </v-row>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -57,6 +57,19 @@
         </v-row>
 
         <v-row>
+          <v-col cols="12">
+            <v-switch
+              v-tippy="{content:'Toggle between only observed targets or all targets', placement: 'left', maxWidth:200}"
+              v-model="formData.observed"
+              color="success"
+              :label="`Targets: ${formData.observed ? 'Observed' : 'All'}`"
+              hide-details
+              inset
+            ></v-switch>
+          </v-col>
+        </v-row>
+
+        <v-row>
           <v-col cols="4">
             <v-btn rounded="lg" color='primary' @click="submit_form" size="large" :disabled="!valid" :append-icon="valid ? 'mdi-check-circle' : 'mdi-close-circle'">Search
               <template v-slot:append>
@@ -137,7 +150,8 @@ let initFormData = {
   units: 'degree',
   release: store.release,
   carton: '',
-  program: ''
+  program: '',
+  observed: true
 }
 // create dynamic bindings to form fields
 let formData = ref({ ...initFormData })


### PR DESCRIPTION
This PR closes #36, and closes #37.  It adds a new toggle UI element to the main search form for observed targets, with default on.  The search results and target page also now display the observed column.  