### PR TITLE
Add caveat to program search

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -4,7 +4,7 @@ import JSONbig from 'json-bigint'
 // Defines the API instance in Axios with special handling for big integers.
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  timeout: 60000,
+  timeout: 1800000,  // making timeout 30 minutes
   transformResponse: [
     function transform(data) {
       // Replacing the default transformResponse in axios because this uses JSON.parse and causes problems

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -55,8 +55,10 @@
           <!-- cartons and programs dropdown menus -->
           <v-col cols="4" md="4">
             <dropdown-select label="Programs" id="programs" :items="store.programs" v-model="formData.program"/>
-            <p class="text-body-2 font-weight-medium mt-1 text-primary" v-tippy="'Searches on programs may take a long time and/or time out. There is a time out limit of 30 minutes. For faster searches, we suggest combining it with a cone search, or searching by carton instead.'">
-              Program Caveat</p>
+            <v-row no-gutters class="d-flex align-center">
+            <p class="text-body-2 font-weight-medium mt-1 text-primary d-flex align-center" v-tippy="'Searches on programs may take a long time and/or time out. There is a time out limit of 30 minutes. For faster searches, we suggest combining it with a cone search, or searching by carton instead.'">
+              <v-icon class='align-center' size="x-small">mdi-help-circle-outline</v-icon>Program Caveat</p>
+            </v-row>
           </v-col>
           <v-col cols="4" md="4">
             <dropdown-select label="Cartons" id="cartons" :items="store.cartons" v-model="formData.carton"/>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -55,6 +55,8 @@
           <!-- cartons and programs dropdown menus -->
           <v-col cols="4" md="4">
             <dropdown-select label="Programs" id="programs" :items="store.programs" v-model="formData.program"/>
+            <p class="text-body-2 font-weight-medium mt-1 text-primary" v-tippy="'Searches on programs may take a long time and/or time out. There is a time out limit of 30 minutes. For faster searches, we suggest combining it with a cone search, or searching by carton instead.'">
+              Program Caveat</p>
           </v-col>
           <v-col cols="4" md="4">
             <dropdown-select label="Cartons" id="cartons" :items="store.cartons" v-model="formData.carton"/>


### PR DESCRIPTION
This PR closes #54 and adds a caveat hover toolip to the Program Search.  It adds a tooltip with the following hover text

"Searches on programs may take a long time and/or time out. There is a time out limit of 30 minutes. For faster searches, we suggest combining it with a cone search, or searching by carton instead."

It also updates the timeout to 30 minutes, from 1 minute, for now until we can converge on a better timeout number.  Some queries might take 1 min 10 secs and maybe that is ok.  
