### PR TITLE
Rearranges db metadata caching

### DIFF
--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -1,5 +1,6 @@
 // Utilities
 import { defineStore } from 'pinia'
+import axiosInstance from '@/axios'
 
 export const useAppStore = defineStore('app', {
   state: () => ({
@@ -84,6 +85,29 @@ export const useAppStore = defineStore('app', {
       let default_val = (this.flat_db[column] === undefined && field === 'display_name') ? column : null
 
       return this.flat_db[column] ? this.flat_db[column][field] : default_val;
+    },
+
+    async get_db_info(refresh: boolean = true) {
+      // get the database metadata info for column descriptions and such
+      // always refresh
+
+      if (!refresh && Object.keys(this.db_info).length !== 0) {
+          console.log('db info already loaded')
+          return
+      }
+
+      await axiosInstance.get('/info/database')
+          .then((response) => {
+              // store the db metadata
+              this.db_info = response.data
+
+              // flatten the db_info object
+              this.flat_db =  Object.fromEntries(Object.entries(this.db_info).flatMap(([schema, table])=>Object.entries(table)))
+
+          })
+          .catch((error) => {
+              console.error(error.toJSON())
+          })
     }
 
   },

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -311,6 +311,9 @@ async function set_fail(msg : string) {
 
 onMounted(() => {
 
+    // get database info
+    store.get_db_info()
+
   // set up API call endpoints
     let endpoints = [
         `/query/list/cartons`,

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -234,27 +234,27 @@ function check_files(data) {
     return empty ? false : true
 }
 
-async function get_db_info() {
+// async function get_db_info() {
 
-    if (Object.keys(store.db_info).length !== 0) {
-        console.log('db info already loaded')
-        return
-    }
+//     if (Object.keys(store.db_info).length !== 0) {
+//         console.log('db info already loaded')
+//         return
+//     }
 
-    await axiosInstance.get('/info/database')
-        .then((response) => {
-            console.log('db info', response.data)
-            // store the db metadata
-            store.db_info = response.data
+//     await axiosInstance.get('/info/database')
+//         .then((response) => {
+//             console.log('db info', response.data)
+//             // store the db metadata
+//             store.db_info = response.data
 
-            // flatten the db_info object
-            store.flat_db =  Object.fromEntries(Object.entries(store.db_info).flatMap(([schema, table])=>Object.entries(table)))
+//             // flatten the db_info object
+//             store.flat_db =  Object.fromEntries(Object.entries(store.db_info).flatMap(([schema, table])=>Object.entries(table)))
 
-        })
-        .catch((error) => {
-            console.error(error.toJSON())
-        })
-}
+//         })
+//         .catch((error) => {
+//             console.error(error.toJSON())
+//         })
+// }
 
 function convert_object( metadata) {
     // temp function for converting to table
@@ -300,7 +300,7 @@ function isHighlighted(item) {
 
 onMounted(() => {
     // get database info
-    get_db_info()
+    store.get_db_info()
 
     // get the available target info
     get_target_info()


### PR DESCRIPTION
This PR closes #55.  It moves the function to get database column metadata to the store, for other components to use.  It also adds a `refresh` keyword to force a refresh of the db cache, and it's currently set to always on.  

We can revisit later if this adds overhead, and possibly change to only refresh after some time-delta of staleness, or something.   