### PR TITLE
Updates to db metadata

### DIFF
--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -327,7 +327,7 @@ onMounted(() => {
         msg.value = 'No search results returned'
     } else {
         data.value = results
-        headers.value = Object.entries(data.value[0]).map((item)=> ({title: store.get_field_from_db(item[0], 'display_name'), key: item[0], type: typeof item[1], description: store.get_field_from_db(item[0], 'description')}))
+        headers.value = Object.entries(data.value[0]).map((item)=> ({title: store.get_field_from_db(item[0], 'display_name', {'schema': 'vizdb'}), key: item[0], type: typeof item[1], description: store.get_field_from_db(item[0], 'description', {'schema': 'vizdb'})}))
         console.log('data', data.value)
         console.log('headers', headers.value)
 

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -243,16 +243,13 @@ function convert_object( metadata) {
 
 function convert_to_table(dataObject, name) {
     // convert target data to v-data-table items with db metadata
-    let mappingObject = store.db_info[name]
     return Object.entries(dataObject).map(([key, value]) => {
-        //const mapping = Object.values(mappingObject).find(db => db[key])?.[key];
-        const mapping = mappingObject[key]
+        const mapping = store.get_obj_from_db(key, {'schema': name})
         return {
             display_name: mapping?.display_name || '',
             column_name: mapping?.column_name || key,
             value: value,
             description: mapping?.description || ''
-
         }
     })
 }


### PR DESCRIPTION
This PR is related to https://github.com/sdss/valis/pull/57 and updates the client-side store functions to better handle non-unique database metadata.  With PR https://github.com/sdss/valis/pull/57 the response from `info/database` now returns a dictionary of schema, with keys `{table}.{column}` whereas before it was organized by `{column}` only.  The front-end now organizes the database metadata by `{schema}.{table}.{column}` for more unique keys, for cases where multiple table and schema have the same column name, but different metadata.  The store function `store.get_field_from_db` now accepts an optional context object specifying a preferred schema or table to use when looking up the field metadata.  e.g. `store.get_field_from_db('sdss_id', 'description', {'schema': 'vizdb'})` will pull the description of the `sdss_id` column from the best matching column in the `vizdb` schema.  