### PR TITLE
Fixes appbar tooltips

### DIFF
--- a/src/layouts/default/AppBar.vue
+++ b/src/layouts/default/AppBar.vue
@@ -18,7 +18,8 @@
 
       <!-- page links -->
       <v-col class="d-none d-sm-flex" id="pagelinks">
-        <v-btn v-for="(item, i) in links" :key="i" :value="item" v-tippy="item.tippy"
+        <v-btn v-for="(item, i) in links" :key="i" :value="item"
+        v-tippy='{"content": `${item.tippy}`, "placement": "bottom", "popperOptions": {"strategy": "fixed"}}'
           :prepend-icon="item.icon">
           <RouterLink :to="item.site">{{item.text}}</RouterLink>
         </v-btn>


### PR DESCRIPTION
This PR closes #73 for the tooltips on the app bar.  The default tooltip option has `interactive: true` to allow for html links inside the tooltip.  But this means the tooltip gains focus when you move the mouse cursor over it.  On the app bar, the auto placement was to the right, causing it so sometimes cover up the next route in the bar.  This PR changes the placement to the bottom and strategy to fixed so the tooltip boundary and expand beyond its parent container.  

See https://vue-tippy.netlify.app/props#popperoptions and https://popper.js.org/docs/v2/constructors/#strategy.   