### PR TITLE
Fix for supporting mwmVisit files

### DIFF
--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -214,7 +214,9 @@ async function get_target_info() {
       carts.value = cartons
       sources.value = catalogs
       pipelines.value = pipes
-      files.value = Object.values(pipes.files).filter(x => x != null && x != '')
+      files.value = Object.values(pipes.files)
+        .flatMap(value => Array.isArray(value) ? value : [value])
+        .filter(filePath => filePath && filePath.trim() !== '');
       console.log('files', files.value, files.value.length)
       has_files.value = check_files(files.value)
       console.log('has_files', has_files.value)


### PR DESCRIPTION
This PR is a small fix to support the change for adding mwmVisit files.  The list of files returned by the valis `target/pipeline` endpoint for `astra` is now a list of files, for the mwmStar and mwmVisit files.  This change flattens the `files` object properly into a single list.  