### PR TITLE
bumping aladin-lite; adding different cat symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mdi/font": "^7.4.47",
-        "aladin-lite": "^3.5.1-beta",
+        "aladin-lite": "^3.6.1-beta",
         "axios": "^1.7.4",
         "core-js": "^3.38.0",
         "json-bigint": "^1.0.0",
@@ -2279,9 +2279,9 @@
       }
     },
     "node_modules/aladin-lite": {
-      "version": "3.5.1-beta",
-      "resolved": "https://registry.npmjs.org/aladin-lite/-/aladin-lite-3.5.1-beta.tgz",
-      "integrity": "sha512-DiBZN4Artv+EdNBgWs6cfwcFWmhSpBrFRCc0enkYQN0xNWNQ/DmbbejbkqhtqrQdqMzWFHSKPl2EayVQ8Izf6g=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/aladin-lite/-/aladin-lite-3.6.4.tgz",
+      "integrity": "sha512-1mQMJR2TrWdBRIfHwhZStsFBr+lSEMVZP3UsmldpAUpUnIJ7LJW9yoW8Xa9WKZQZ9NX+XmlxrfaKRt4IF4nSEw=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",
-    "aladin-lite": "^3.5.1-beta",
+    "aladin-lite": "^3.6.1-beta",
     "axios": "^1.7.4",
     "core-js": "^3.38.0",
     "json-bigint": "^1.0.0",

--- a/src/components/CatalogTable.vue
+++ b/src/components/CatalogTable.vue
@@ -15,6 +15,44 @@
     <!-- top toolbar -->
     <template v-slot:top>
         <div class="d-flex align-center flex-wrap">
+            <!-- target symbol legend -->
+            <v-dialog max-width="500">
+                <template v-slot:activator="{ props: activatorProps }">
+                <v-btn
+                    v-bind="activatorProps"
+                    rounded="0"
+                    variant="tonal"
+                    icon="mdi-symbol"
+                    v-tippy="{content: 'Legend for target symbols', placement: 'right-end'}"
+                ></v-btn>
+                </template>
+
+                <template v-slot:default="{ isActive }">
+                <v-card class="mx-auto" max-width="300">
+                    <v-list disabled>
+                    <v-list-subheader>Symbol Legend</v-list-subheader>
+
+                    <v-list-item v-for="(item, i) in targsymbols" :key="i">
+                        <template v-slot:prepend>
+                        <v-icon :icon="item.icon"></v-icon>
+                        </template>
+
+                        <v-list-item-title v-text="item.text"></v-list-item-title>
+                    </v-list-item>
+                    </v-list>
+                    <v-card-actions>
+                    <v-spacer></v-spacer>
+
+                    <v-btn
+                    text="Close"
+                    @click="isActive.value = false"
+                    ></v-btn>
+                    </v-card-actions>
+                </v-card>
+                </template>
+            </v-dialog>
+
+            <!-- export table button -->
             <ExportTable :data="props.items" :short="true"/>
         </div>
     </template>
@@ -47,6 +85,12 @@ let sortBy = ref([])
 let temph = Object.entries(props.items[0]).map((item)=> ({title: item[0], key: item[0], type: typeof item[1], description: store.get_field_from_db(item[0], 'description')}))
 let headers = reorderArrayObjects(temph, ['sdss_id', 'ra_sdss_id', 'dec_sdss_id', 'has_been_observed', 'in_boss', 'in_apogee', 'in_astra']);
 
+const targsymbols = [
+    { text: 'MWM-only', icon: 'mdi-square-outline' },
+    { text: 'BHM-only', icon: 'mdi-circle-outline' },
+    { text: 'BHM + MWM', icon: 'mdi-triangle-outline' },
+    { text: 'Astra DR17-processed', icon: 'mdi-close-outline' },
+  ]
 
 function reorderArrayObjects(arr, priorityOrder) {
   // Create a map for quick lookup of priority order

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -339,10 +339,27 @@ async function coneSearch(ra: string, dec: string, radius: number, units: string
         });
 }
 
+function setShape(source) {
+    // set the shape of the source based on its property
+    if (source.data.in_boss && !source.data.in_apogee ) {
+        // BHM-only
+        return 'circle'
+    } else if (!source.data.in_boss && source.data.in_apogee ) {
+        // MWM-only
+        return 'square'
+    } else if (source.data.in_boss && source.data.in_apogee && source.data.in_astra) {
+        // BHM-MWM-Astra
+        return 'triangle'
+    } else {
+        // Astra DR17-processed
+        return 'cross'
+    }
+}
+
 function addCatalog(data: Array<object>, aladin: any, name: string, size: number = 18) {
     // add a new aladin catalog of sources
 
-    var cat = A.catalog({name: name, sourceSize: size, onClick: 'showPopup'});
+    var cat = A.catalog({name: name, sourceSize: size, onClick: 'showPopup', shape: setShape});
     aladin.addCatalog(cat);
 
     // test marker with popup


### PR DESCRIPTION
This PR closes #76 and adds new symbols for catalog subsets of the cone search results on the explore page.  The different symbols are based on which pipeline processing it has gone through.  

- BWM-only: circle
- MWM-only: square
- BWM+MWM: triangle
- Astra DR17-processed only: cross