### PR TITLE
Redoes the target pipelines section 

### DIFF
--- a/src/components/PipelineInfoModal.vue
+++ b/src/components/PipelineInfoModal.vue
@@ -1,0 +1,313 @@
+<template>
+    <v-btn
+        size="small"
+        color="success"
+        rounded="0"
+        variant="tonal"
+        @click="openDialog"
+    >
+        Show
+    </v-btn>
+
+    <v-dialog v-model="dialog" max-width="700px" max-height="600px">
+        <v-card class="d-flex flex-column">
+            <v-card-title class="text-h6">
+                <v-row no-gutters align="center">
+                    <v-col>{{ title }}</v-col>
+                    <v-col text-end cols="auto">
+                        <v-btn
+                            density="compact"
+                            color="secondary"
+                            size="small"
+                            icon="mdi-close"
+                            @click="dialog = false"
+                        ></v-btn>
+                    </v-col>
+                </v-row>
+            </v-card-title>
+            <v-card-subtitle class="d-flex align-center justify-space-between">
+                <span>Target: {{ targetSdssid }}</span>
+                <span>(Null values excluded from display)</span>
+            </v-card-subtitle>
+            <v-divider class="mb-0 mt-2"></v-divider>
+
+            <v-card-text class="pa-0 ma-0" style="height: 500px; overflow: hidden;">
+                <v-row no-gutters class="fill-height">
+                    <v-col class="data-table-container">
+                        <div v-if="loading" class="pa-4">
+                            <v-progress-linear indeterminate color="blue-lighten-3"></v-progress-linear>
+                        </div>
+                        <v-alert v-else-if="error" type="error" variant="tonal" class="ma-4">
+                            {{ error }}
+                        </v-alert>
+                        <v-alert v-else-if="tableData.length === 0" type="info" variant="tonal" class="ma-4">
+                            No pipeline parameters available for this row.
+                        </v-alert>
+                        <v-data-table-virtual
+                            v-else
+                            :headers="headers"
+                            :items="tableData"
+                            density="compact"
+                            height="500"
+                            fixed-header
+                        >
+                            <template #item.parameter="{ item }">
+                                <span v-tippy="item.description || undefined">{{ item.parameter }}</span>
+                            </template>
+                        </v-data-table-virtual>
+                    </v-col>
+
+                    <v-col cols="4" class="item-list-container">
+                        <v-list
+                            lines="one"
+                            density="compact"
+                            style="height: 100%; overflow-y: auto; padding-left: 0;"
+                            border="sm"
+                        >
+                            <v-list-item
+                                v-for="(row, index) in props.rows"
+                                :key="rowKey(row, index)"
+                                :active="isSelectedRow(row)"
+                                :border="index !== props.rows.length - 1 ? 'b' : ''"
+                                style="padding: 0;"
+                            >
+                                <v-list-item-title class="text-left">
+                                    <v-btn
+                                        color="primary"
+                                        variant="plain"
+                                        class="text-left"
+                                        style="justify-content: flex-start; text-align: left;"
+                                        @click="selectRow(row)"
+                                    >
+                                        {{ rowLabel(row) }}
+                                    </v-btn>
+                                </v-list-item-title>
+                            </v-list-item>
+                        </v-list>
+                    </v-col>
+                </v-row>
+            </v-card-text>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import axiosInstance from '@/axios'
+import { useAppStore } from '@/store/app'
+
+type PipelineSource = {
+    pipeline: 'boss' | 'apogee'
+}
+
+// Define strongly-typed component props.
+const props = defineProps<{
+    sdssid: string | string[]
+    rows: Record<string, any>[]
+    summaryRow: Record<string, any>
+    source: PipelineSource
+}>()
+
+const store = useAppStore()  // Access the global application store.
+const storeAny = store as any  // Use loose typing for dynamic store helpers.
+
+const dialog = ref(false)  // Controls the modal visibility.
+const loading = ref(false) // Tracks whether a request is in progress.
+const error = ref('') // Stores the current error message.
+const selectedRow = ref<Record<string, any> | null>(null) // Stores the currently selected pipeline row.
+const tableData = ref<TableItem[]>([]) // Holds table-ready pipeline parameters.
+const cache = ref<Record<string, TableItem[]>>({}) // Caches transformed rows by dbid.
+
+// Defines the table headers.
+const headers = [
+    { title: 'Parameter', key: 'parameter' },
+    { title: 'Value', key: 'value' }
+]
+
+// Derives dbid key and schema from pipeline type.
+const pipelineConfig = computed(() => {
+    if (props.source.pipeline === 'boss') {
+        return { dbidKey: 'id', schema: 'boss_drp' }
+    }
+    return { dbidKey: 'pk', schema: 'apogee_drp' }
+})
+
+// Normalizes sdssid into a single string.
+const targetSdssid = computed(() => {
+    return Array.isArray(props.sdssid) ? props.sdssid[0] || '' : props.sdssid
+})
+
+// Builds a dynamic dialog title for the selected pipeline row.
+const title = computed(() => {
+    if (props.source.pipeline === 'boss') {
+        return 'Boss DRP Pipeline Parameters'
+    }
+    // Determine the APOGEE observation type.
+    const obstype = selectedRow.value?._rowtype || 'star'
+    // Build a short observation label for the title.
+    const obs = obstype === 'visit' ? 'Visit' : 'Star'
+    return `Apogee DRP Pipeline Parameters (${obs})`
+})
+
+/** Return the database identifier for a row. */
+function rowDbid(row: Record<string, any>): string {
+    // Read the configured dbid value from the row.
+    const value = row?.[pipelineConfig.value.dbidKey]
+    return value == null ? '' : String(value)
+}
+
+/** Build a stable key for each selectable row. */
+function rowKey(row: Record<string, any>, index: number): string {
+    return rowDbid(row) || `${props.source.pipeline}-row-${index}`
+}
+
+/** Format the visible label for a selectable row. */
+function rowLabel(row: Record<string, any>): string {
+    if (props.source.pipeline === 'boss') {
+        // Build a BOSS row label from coadd and MJD.
+        const parts = [row.coadd, row.mjd].filter((v) => v != null && `${v}`.trim() !== '')
+        return parts.length > 0 ? parts.join(' | ') : rowDbid(row)
+    }
+    // apogee
+    // Determine if this APOGEE row is star or visit.
+    const rowtype = row._rowtype || 'star'
+    if (rowtype === 'visit') {
+        // Build an APOGEE visit label.
+        const parts = ['visit', row.mjd, row.field].filter((v) => v != null && `${v}`.trim() !== '')
+        return parts.join(' | ')
+    }
+    return ['star', row.starver].filter((v) => v != null && `${v}`.trim() !== '').join(' | ')
+}
+
+/** Check whether a row is currently selected. */
+function isSelectedRow(row: Record<string, any>): boolean {
+    if (!selectedRow.value) return false
+    return rowDbid(selectedRow.value) === rowDbid(row)
+}
+
+/** Convert complex values into display-safe primitives. */
+function formatValue(value: unknown): string | number | boolean {
+    if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+        return JSON.stringify(value)
+    }
+    return value as string | number | boolean
+}
+
+type TableItem = {
+    parameter: string
+    value: string | number | boolean
+    description: string
+    column: string
+}
+
+/** Transform API data into table items with metadata. */
+function toTableData(data: Record<string, unknown>): TableItem[] {
+    // Resolve the metadata schema for the active pipeline.
+    const schema = pipelineConfig.value.schema
+    return Object.entries(data)
+        .filter(([, value]) => value !== null && value !== undefined)
+        .map(([column, value]) => {
+            // Lookup strict metadata for this schema and column.
+            const meta = getColumnMetaStrict(column, schema)
+            return {
+                column,
+                parameter: meta.display_name || column,
+                description: meta.description || '',
+                value: formatValue(value)
+            }
+        })
+}
+
+/** Resolve column metadata strictly within one schema. */
+function getColumnMetaStrict(column: string, schema: string): Record<string, any> {
+    // Collect all known flattened keys for this column name.
+    const possibleKeys = storeAny?.dbkey_lookup?.[column] || []
+    if (!Array.isArray(possibleKeys) || possibleKeys.length === 0) return {}
+
+    // Keep only keys that belong to the requested schema.
+    const schemaMatches = possibleKeys.filter((key: string) => key.startsWith(`${schema}.`) && key.endsWith(`.${column}`))
+    if (schemaMatches.length === 0) return {}
+
+    return storeAny?.flat_db?.[schemaMatches[0]] || {}
+}
+
+/** Open the modal and load the initial row. */
+function openDialog() {
+    dialog.value = true
+    selectRow(props.summaryRow)
+}
+
+/** Fetch and display parameters for a selected row. */
+async function selectRow(row: Record<string, any>) {
+    selectedRow.value = row
+    error.value = ''
+
+    // Resolve the dbid for the selected row.
+    const dbid = rowDbid(row)
+    if (!dbid) {
+        tableData.value = []
+        error.value = `Missing ${pipelineConfig.value.dbidKey} for selected row.`
+        return
+    }
+
+    if (cache.value[dbid]) {
+        tableData.value = cache.value[dbid]
+        return
+    }
+
+    loading.value = true
+
+    // Build the correct API endpoint for the active pipeline.
+    const endpoint = props.source.pipeline === 'boss'
+        ? `/target/pipe/boss/${targetSdssid.value}`
+        : `/target/pipe/apogee/${targetSdssid.value}`
+
+    // Build baseline request params.
+    const params: Record<string, string> = {
+        release: store.release,
+        dbid
+    }
+
+    if (props.source.pipeline === 'boss' && row.coadd) {
+        params.coadd = row.coadd
+    }
+
+    if (props.source.pipeline === 'apogee') {
+        params.obstype = row._rowtype || 'star'
+    }
+
+    // Attach auth headers when available.
+    const authHeaders = storeAny.get_auth_hdr ? storeAny.get_auth_hdr() : {}
+
+    await axiosInstance.get(endpoint, { params, headers: authHeaders })
+        .then(({ data }) => {
+            // Transform API data and store it in cache.
+            const transformed = toTableData(data || {})
+            cache.value[dbid] = transformed
+            tableData.value = transformed
+        })
+        .catch((err) => {
+            console.error('PipelineInfoModal fetch error:', err)
+            // Show a useful error message in the modal.
+            const message = err?.response?.data?.detail || err?.toJSON?.().message || 'Error loading pipeline parameters.'
+            error.value = message
+            tableData.value = []
+        })
+        .finally(() => {
+            loading.value = false
+        })
+}
+</script>
+
+<style>
+.data-table-container {
+    overflow-y: hidden;
+    max-height: 100%;
+}
+
+.item-list-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+</style>

--- a/src/components/PipelineInfoModal.vue
+++ b/src/components/PipelineInfoModal.vue
@@ -116,7 +116,7 @@ const loading = ref(false) // Tracks whether a request is in progress.
 const error = ref('') // Stores the current error message.
 const selectedRow = ref<Record<string, any> | null>(null) // Stores the currently selected pipeline row.
 const tableData = ref<TableItem[]>([]) // Holds table-ready pipeline parameters.
-const cache = ref<Record<string, TableItem[]>>({}) // Caches transformed rows by dbid.
+const cache = ref<Record<string, TableItem[]>>({}) // Caches transformed rows by release and dbid.
 
 // Defines the table headers.
 const headers = [
@@ -158,7 +158,26 @@ function rowDbid(row: Record<string, any>): string {
 
 /** Build a stable key for each selectable row. */
 function rowKey(row: Record<string, any>, index: number): string {
-    return rowDbid(row) || `${props.source.pipeline}-row-${index}`
+    const dbid = rowDbid(row)
+    if (!dbid) return `${props.source.pipeline}-row-${index}`
+
+    if (props.source.pipeline === 'apogee') {
+        const obstype = row._rowtype || 'star'
+        return `${dbid}:${obstype}`
+    }
+
+    return dbid
+}
+
+/** Build a cache key from release, dbid, and pipeline label. */
+function buildCacheKey(row: Record<string, any>, dbid: string): string {
+    if (props.source.pipeline === 'boss') {
+        const coadd = row.coadd ? String(row.coadd) : 'none'
+        return `${store.release}:${dbid}:${coadd}`
+    }
+
+    const obstype = row._rowtype || 'star'
+    return `${store.release}:${dbid}:${obstype}`
 }
 
 /** Format the visible label for a selectable row. */
@@ -250,8 +269,11 @@ async function selectRow(row: Record<string, any>) {
         return
     }
 
-    if (cache.value[dbid]) {
-        tableData.value = cache.value[dbid]
+    // Build a release-aware cache key for this row.
+    const cacheKey = buildCacheKey(row, dbid)
+
+    if (cache.value[cacheKey]) {
+        tableData.value = cache.value[cacheKey]
         return
     }
 
@@ -283,7 +305,7 @@ async function selectRow(row: Record<string, any>) {
         .then(({ data }) => {
             // Transform API data and store it in cache.
             const transformed = toTableData(data || {})
-            cache.value[dbid] = transformed
+            cache.value[cacheKey] = transformed
             tableData.value = transformed
         })
         .catch((err) => {

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -84,14 +84,19 @@
                                                 </template> -->
                                                 <!-- pipe info menu item -->
                                                 <template v-slot:item.pipeinfo="{ item }">
-                                                    <v-btn color="success" density="compact" rounded="0" variant="tonal">Show</v-btn>
+                                                    <pipeline-info-modal
+                                                        :sdssid="sdss_id"
+                                                        :rows="pipelines.boss || []"
+                                                        :summary-row="item"
+                                                        :source="{ pipeline: 'boss' }"
+                                                    ></pipeline-info-modal>
                                                 </template>
                                                 <template v-slot:item.specprimary="{ item }">
                                                     <v-icon v-if="item.specprimary">mdi-check</v-icon>
                                                 </template>
                                                 <template v-slot:item.stem="{ item }">
                                                     <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">{{ item.stem }}</a>
-                                                    <span v-else>No product available</span>
+                                                    <span v-else>No file available</span>
                                                 </template>
                                             </v-data-table-virtual>
                                         </v-expansion-panel-text>
@@ -111,15 +116,25 @@
                                                         density="compact"
                                                         :sort-by="[{ key: 'starver', order: 'asc' }]"
                                                     >
+                                                        <template v-slot:item.product="{ item }">
+                                                            {{  item.product ? item.product : 'apStar'}}
+                                                        </template>
+
                                                         <!-- pipe info menu item -->
                                                         <template v-slot:item.pipeinfo="{ item }">
-                                                            <v-btn color="success" density="compact" rounded="0" variant="tonal">Show</v-btn>
+                                                            <pipeline-info-modal
+                                                                :sdssid="sdss_id"
+                                                                :rows="apogeeAllRows"
+                                                                :summary-row="item"
+                                                                :source="{ pipeline: 'apogee' }"
+                                                            ></pipeline-info-modal>
                                                         </template>
+
                                                         <template #item.stem="{ item }">
                                                         <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
                                                             {{ item.stem }}
                                                         </a>
-                                                        <span v-else>No product available</span>
+                                                        <span v-else>No file available</span>
                                                         </template>
                                                     </v-data-table-virtual>
                                                     </v-expansion-panel-text>
@@ -134,15 +149,24 @@
                                                         density="compact"
                                                         :sort-by="[{ key: 'mjd', order: 'asc' }]"
                                                     >
+                                                        <template v-slot:item.product="{ item }">
+                                                            {{  item.product ? item.product : 'apVisit'}}
+                                                        </template>
+
                                                         <!-- pipe info menu item -->
                                                         <template v-slot:item.pipeinfo="{ item }">
-                                                            <v-btn color="success" density="compact" rounded="0" variant="tonal">Show</v-btn>
+                                                            <pipeline-info-modal
+                                                                :sdssid="sdss_id"
+                                                                :rows="apogeeAllRows"
+                                                                :summary-row="item"
+                                                                :source="{ pipeline: 'apogee' }"
+                                                            ></pipeline-info-modal>
                                                         </template>
                                                         <template #item.stem="{ item }">
                                                         <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
                                                             {{ item.stem }}
                                                         </a>
-                                                        <span v-else>No product available</span>
+                                                        <span v-else>No file available</span>
                                                         </template>
                                                     </v-data-table-virtual>
                                                     </v-expansion-panel-text>
@@ -161,7 +185,7 @@
                                                     <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
                                                         {{ item.stem }}
                                                     </a>
-                                                    <span v-else>No product available</span>
+                                                    <span v-else>No file available</span>
                                                 </template>
                                             </v-data-table-virtual>
                                         </v-expansion-panel-text>
@@ -246,6 +270,7 @@ import DataDownload from '@/components/DataDownload.vue'
 import useStoredTheme from '@/composables/useTheme'
 import ParentCatalog from '@/components/ParentCatalog.vue'
 import AstraPipeline from '@/components/AstraPipeline.vue'
+import PipelineInfoModal from '@/components/PipelineInfoModal.vue'
 
 import axiosInstance from '@/axios'
 
@@ -336,7 +361,7 @@ const apogeeStars = computed(() => {
   const stars = pipelines.value?.apogee?.stars ?? []
   return stars.map((row: any) => ({
     ...row,
-    product: row.product || 'apStar',
+    _rowtype: 'star',
   }))
 })
 
@@ -344,9 +369,11 @@ const apogeeVisits = computed(() => {
   const visits = pipelines.value?.apogee?.visits ?? []
   return visits.map((row: any) => ({
     ...row,
-    product: row.product || 'apVisit',
+    _rowtype: 'visit',
   }))
 })
+
+const apogeeAllRows = computed(() => [...apogeeStars.value, ...apogeeVisits.value])
 
 let headmeta = [
     {key: 'display_name', title: 'Display Name'},

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -58,7 +58,7 @@
                                     <!-- astra source info -->
                                     <v-expansion-panel title="Astra Source Info">
                                         <v-expansion-panel-text>
-                                            <v-data-table-virtual :items="convert_object(pipelines.astra)" density="compact"></v-data-table-virtual>
+                                            <v-data-table-virtual :items="convert_object(pipelines.astra.source)" density="compact"></v-data-table-virtual>
                                         </v-expansion-panel-text>
                                     </v-expansion-panel>
 
@@ -78,17 +78,92 @@
                                     <!-- boss drp info -->
                                     <v-expansion-panel title="Boss DRP Pipeline Info">
                                         <v-expansion-panel-text>
-                                            <v-data-table-virtual :items="convert_to_table(pipelines.boss, 'boss_drp')" density="compact">
-                                                <template v-slot:item.display_name="{ item }">
+                                            <v-data-table-virtual :items="pipelines.boss" :headers="bosshead" density="compact">
+                                                <!-- <template v-slot:item.display_name="{ item }">
                                                     <p v-tippy="item.description">{{ item.display_name }}</p>
+                                                </template> -->
+                                                <!-- pipe info menu item -->
+                                                <template v-slot:item.pipeinfo="{ item }">
+                                                    <v-btn color="success" density="compact" rounded="0" variant="tonal">Show</v-btn>
+                                                </template>
+                                                <template v-slot:item.specprimary="{ item }">
+                                                    <v-icon v-if="item.specprimary">mdi-check</v-icon>
+                                                </template>
+                                                <template v-slot:item.stem="{ item }">
+                                                    <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">{{ item.stem }}</a>
+                                                    <span v-else>No product available</span>
                                                 </template>
                                             </v-data-table-virtual>
                                         </v-expansion-panel-text>
                                     </v-expansion-panel>
+
                                     <!-- apogee drp info -->
                                     <v-expansion-panel title="Apogee DRP Pipeline Info">
                                         <v-expansion-panel-text>
-                                            <v-data-table-virtual :items="convert_object(pipelines.apogee)" density="compact"></v-data-table-virtual>
+                                            <!--<v-data-table-virtual :items="convert_object(pipelines.apogee)" density="compact"></v-data-table-virtual>-->
+                                                <v-expansion-panels variant="accordion" multiple v-model="apopanels">
+                                                <v-expansion-panel title="Stars">
+                                                    <v-expansion-panel-text>
+                                                    <v-data-table-virtual
+                                                        :items="apogeeStars"
+                                                        :headers="apogeeStarsHead"
+                                                        item-value="pk"
+                                                        density="compact"
+                                                        :sort-by="[{ key: 'starver', order: 'asc' }]"
+                                                    >
+                                                        <!-- pipe info menu item -->
+                                                        <template v-slot:item.pipeinfo="{ item }">
+                                                            <v-btn color="success" density="compact" rounded="0" variant="tonal">Show</v-btn>
+                                                        </template>
+                                                        <template #item.stem="{ item }">
+                                                        <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
+                                                            {{ item.stem }}
+                                                        </a>
+                                                        <span v-else>No product available</span>
+                                                        </template>
+                                                    </v-data-table-virtual>
+                                                    </v-expansion-panel-text>
+                                                </v-expansion-panel>
+
+                                                <v-expansion-panel title="Visits">
+                                                    <v-expansion-panel-text>
+                                                    <v-data-table-virtual
+                                                        :items="apogeeVisits"
+                                                        :headers="apogeeVisitsHead"
+                                                        item-value="pk"
+                                                        density="compact"
+                                                        :sort-by="[{ key: 'mjd', order: 'asc' }]"
+                                                    >
+                                                        <!-- pipe info menu item -->
+                                                        <template v-slot:item.pipeinfo="{ item }">
+                                                            <v-btn color="success" density="compact" rounded="0" variant="tonal">Show</v-btn>
+                                                        </template>
+                                                        <template #item.stem="{ item }">
+                                                        <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
+                                                            {{ item.stem }}
+                                                        </a>
+                                                        <span v-else>No product available</span>
+                                                        </template>
+                                                    </v-data-table-virtual>
+                                                    </v-expansion-panel-text>
+                                                </v-expansion-panel>
+                                                </v-expansion-panels>
+
+
+                                        </v-expansion-panel-text>
+                                    </v-expansion-panel>
+
+                                   <!-- astra products info -->
+                                    <v-expansion-panel title="Astra Products">
+                                        <v-expansion-panel-text>
+                                            <v-data-table-virtual :headers="astraHead" :items="pipelines.astra.products" density="compact">
+                                                <template #item.stem="{ item }">
+                                                    <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
+                                                        {{ item.stem }}
+                                                    </a>
+                                                    <span v-else>No product available</span>
+                                                </template>
+                                            </v-data-table-virtual>
                                         </v-expansion-panel-text>
                                     </v-expansion-panel>
 
@@ -196,6 +271,7 @@ let legacydata = ref([])
 let cartSort = [{ key: 'run_on', order: 'desc' }]
 let metapanels = ref([0])
 let pipepanels = ref(null)
+let apopanels = ref([0])
 let files = ref([])
 let has_files = ref(false)
 
@@ -225,6 +301,52 @@ let headcart = [
     {key: 'category', title: 'Category'},
     {key: 'run_on', title: 'Date Run On'},
 ]
+
+let bosshead = [
+    {key: 'product', title: 'Product'},
+    {key: 'mjd', title: 'MJD'},
+    {key: 'coadd', title: 'Coadd'},
+    {key: 'specprimary', title: 'Specprimary'},
+    {key: 'stem', title: 'File'},
+    {key: 'pipeinfo', title: 'Pipeline Parameters'},
+]
+
+const apogeeStarsHead = [
+  { key: 'product', title: 'Product' },
+  { key: 'starver', title: 'StarVer' },
+  { key: 'nvisits', title: 'NVisits' },
+  { key: 'stem', title: 'File' },
+  {key: 'pipeinfo', title: 'Pipeline Parameters'},
+]
+
+const apogeeVisitsHead = [
+  { key: 'product', title: 'Product' },
+  { key: 'mjd', title: 'MJD' },
+  { key: 'field', title: 'Field' },
+  { key: 'stem', title: 'File' },
+{key: 'pipeinfo', title: 'Pipeline Parameters'},
+]
+
+const astraHead = [
+  { key: 'product', title: 'Product' },
+  { key: 'stem', title: 'File' },
+]
+
+const apogeeStars = computed(() => {
+  const stars = pipelines.value?.apogee?.stars ?? []
+  return stars.map((row: any) => ({
+    ...row,
+    product: row.product || 'apStar',
+  }))
+})
+
+const apogeeVisits = computed(() => {
+  const visits = pipelines.value?.apogee?.visits ?? []
+  return visits.map((row: any) => ({
+    ...row,
+    product: row.product || 'apVisit',
+  }))
+})
 
 let headmeta = [
     {key: 'display_name', title: 'Display Name'},

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -333,7 +333,7 @@ let bosshead = [
     {key: 'coadd', title: 'Coadd'},
     {key: 'specprimary', title: 'Specprimary'},
     {key: 'stem', title: 'File'},
-    {key: 'pipeinfo', title: 'Pipeline Parameters'},
+    {key: 'pipeinfo', title: 'Parameters'},
 ]
 
 const apogeeStarsHead = [
@@ -341,7 +341,7 @@ const apogeeStarsHead = [
   { key: 'starver', title: 'StarVer' },
   { key: 'nvisits', title: 'NVisits' },
   { key: 'stem', title: 'File' },
-  {key: 'pipeinfo', title: 'Pipeline Parameters'},
+  {key: 'pipeinfo', title: 'Parameters'},
 ]
 
 const apogeeVisitsHead = [
@@ -349,7 +349,7 @@ const apogeeVisitsHead = [
   { key: 'mjd', title: 'MJD' },
   { key: 'field', title: 'Field' },
   { key: 'stem', title: 'File' },
-{key: 'pipeinfo', title: 'Pipeline Parameters'},
+{key: 'pipeinfo', title: 'Parameters'},
 ]
 
 const astraHead = [

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -79,9 +79,6 @@
                                     <v-expansion-panel title="Boss DRP Pipeline Info">
                                         <v-expansion-panel-text>
                                             <v-data-table-virtual :items="pipelines.boss" :headers="bosshead" density="compact">
-                                                <!-- <template v-slot:item.display_name="{ item }">
-                                                    <p v-tippy="item.description">{{ item.display_name }}</p>
-                                                </template> -->
                                                 <!-- pipe info menu item -->
                                                 <template v-slot:item.pipeinfo="{ item }">
                                                     <pipeline-info-modal
@@ -95,7 +92,7 @@
                                                     <v-icon v-if="item.specprimary">mdi-check</v-icon>
                                                 </template>
                                                 <template v-slot:item.stem="{ item }">
-                                                    <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">{{ item.stem }}</a>
+                                                    <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank" rel="noopener noreferrer">{{ item.stem }}</a>
                                                     <span v-else>No file available</span>
                                                 </template>
                                             </v-data-table-virtual>
@@ -105,7 +102,6 @@
                                     <!-- apogee drp info -->
                                     <v-expansion-panel title="Apogee DRP Pipeline Info">
                                         <v-expansion-panel-text>
-                                            <!--<v-data-table-virtual :items="convert_object(pipelines.apogee)" density="compact"></v-data-table-virtual>-->
                                                 <v-expansion-panels variant="accordion" multiple v-model="apopanels">
                                                 <v-expansion-panel title="Stars">
                                                     <v-expansion-panel-text>
@@ -163,7 +159,7 @@
                                                             ></pipeline-info-modal>
                                                         </template>
                                                         <template #item.stem="{ item }">
-                                                        <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
+                                                        <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank" rel="noopener noreferrer" >
                                                             {{ item.stem }}
                                                         </a>
                                                         <span v-else>No file available</span>
@@ -182,7 +178,7 @@
                                         <v-expansion-panel-text>
                                             <v-data-table-virtual :headers="astraHead" :items="pipelines.astra.products" density="compact">
                                                 <template #item.stem="{ item }">
-                                                    <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank">
+                                                    <a v-if="item.stem" :href="'https://data.sdss5.org/sas/' + item.location" target="_blank" rel="noopener noreferrer" >
                                                         {{ item.stem }}
                                                     </a>
                                                     <span v-else>No file available</span>
@@ -194,7 +190,7 @@
                                    <!-- astra pipelines info -->
                                     <v-expansion-panel v-if="pipelines.astra_pipelines" title="Astra Pipelines">
                                         <v-expansion-panel-text>
-                                            <span><p>The available pipelines for this target. For detailed info, see the <a :href="astraPipelinesUrl" target="_blank">Pipelines in Astra</a> documentation.</p></span>
+                                            <span><p>The available pipelines for this target. For detailed info, see the <a :href="astraPipelinesUrl" target="_blank" rel="noopener noreferrer">Pipelines in Astra</a> documentation.</p></span>
                                             <astra-pipeline :sdssid="sdss_id" :pipelines="pipelines.astra_pipelines"></astra-pipeline>
                                         </v-expansion-panel-text>
                                     </v-expansion-panel>
@@ -230,11 +226,11 @@
                             <v-data-table :items="legacydata" :headers="headlegacy" density="compact">
                                 <!-- add checkmark for in_boss boolean -->
                                 <template v-slot:item.sas_url="{ item }">
-                                    <a :href="item.sas_url" target="_blank">link</a>
+                                    <a :href="item.sas_url" target="_blank" rel="noopener noreferrer" >link</a>
                                 </template>
                                 <!-- add checkmark for in_boss boolean -->
                                 <template v-slot:item.cas_url="{ item }">
-                                    <a :href="item.cas_url" target="_blank">link</a>
+                                    <a :href="item.cas_url" target="_blank" rel="noopener noreferrer" >link</a>
                                 </template>
                             </v-data-table>
                         </v-window-item>
@@ -349,7 +345,7 @@ const apogeeVisitsHead = [
   { key: 'mjd', title: 'MJD' },
   { key: 'field', title: 'Field' },
   { key: 'stem', title: 'File' },
-{key: 'pipeinfo', title: 'Parameters'},
+  {key: 'pipeinfo', title: 'Parameters'},
 ]
 
 const astraHead = [


### PR DESCRIPTION
This PR updates the Target pipelines section to produce list of results for the given sdss_id and release.  It now fills out a table of results/products with limited summary info.  The full pipeline parameters are now moved into an on-demand call, similar to the astra pipeline and parent catalog components.  Related to https://github.com/sdss/valis/pull/88

## boss
<img width="1306" height="672" alt="Screenshot 2026-04-29 at 3 04 22 PM" src="https://github.com/user-attachments/assets/5641226a-3c1d-4451-8c0a-38b58e08b83c" />
<img width="774" height="620" alt="Screenshot 2026-04-29 at 3 23 24 PM" src="https://github.com/user-attachments/assets/2e03d6b9-2284-494f-a0ad-23072cb03063" />


## apogee
<img width="1258" height="416" alt="Screenshot 2026-04-29 at 3 05 10 PM" src="https://github.com/user-attachments/assets/7bd3d694-06b5-4956-985c-37ccb51d946e" />

<img width="729" height="607" alt="Screenshot 2026-04-29 at 3 05 33 PM" src="https://github.com/user-attachments/assets/4639c044-2954-4c2d-9062-a14ae03a8857" />

