### PR TITLE
allowing the pipe tables to scroll

### DIFF
--- a/src/components/Solara.vue
+++ b/src/components/Solara.vue
@@ -33,7 +33,9 @@ let valid = ref(false)
 let errmsg = ref('')
 let theme = useTheme()
 
-let url = ref(import.meta.env.VITE_API_URL + `/solara/embed/?release=${store.release}&sdssid=${props.sdssid}&files=${props.files.join()}&theme=${theme.global.name.value}`)
+// encode the file paths for any + in the filename, e.g. apStar
+const urienc = props.files.map(encodeURIComponent)
+let url = ref(import.meta.env.VITE_API_URL + `/solara/embed/?release=${store.release}&sdssid=${props.sdssid}&files=${urienc.join()}&theme=${theme.global.name.value}`)
 console.log('url', url)
 
 async function check_solara() {

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -78,7 +78,7 @@
                                     <!-- boss drp info -->
                                     <v-expansion-panel title="Boss DRP Info">
                                         <v-expansion-panel-text>
-                                            <v-data-table-virtual :items="pipelines.boss" :headers="bosshead" density="compact">
+                                            <v-data-table-virtual class="pipeline-scroll-table" :items="pipelines.boss" :headers="bosshead" density="compact">
                                                 <!-- pipe info menu item -->
                                                 <template v-slot:item.pipeinfo="{ item }">
                                                     <pipeline-info-modal
@@ -141,6 +141,7 @@
                                                 <v-expansion-panel title="Visits">
                                                     <v-expansion-panel-text>
                                                     <v-data-table-virtual
+                                                        class="pipeline-scroll-table"
                                                         :items="apogeeVisits"
                                                         :headers="apogeeVisitsHead"
                                                         item-value="pk"
@@ -585,5 +586,14 @@ onMounted(() => {
 
 .v-theme--dark .highlighted-row {
   background-color: rgba(255, 255, 255, 0.1) !important; /* Lighter shade in dark theme */
+}
+
+.pipeline-scroll-table {
+    max-height: 420px;
+}
+
+.pipeline-scroll-table .v-table__wrapper {
+    max-height: 420px;
+    overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
Closes #133 .  This updates the pipeline tables to scroll vertically when the number of products in the table is long and overflows the space.  It no longer pushes the page down.  