### PR TITLE
Updates to fix query too long issue

### DIFF
--- a/src/components/Solara.vue
+++ b/src/components/Solara.vue
@@ -19,6 +19,7 @@ const store = useAppStore()
 const props = defineProps<{
     sdssid: string,
     files: Array<string>,
+    first: string
 }>()
 
 // set the body attributes for solara popout
@@ -28,19 +29,23 @@ const pathname = (vurl.pathname.endsWith('/')) ? vurl.pathname : vurl.pathname +
 document.body.setAttribute('data-base-url', pathname)
 document.body.setAttribute('data-voila-host', vurl.origin)
 
-let iframe = ref(null)
+let iframe = ref<HTMLIFrameElement | null>(null)
 let valid = ref(false)
 let errmsg = ref('')
 let theme = useTheme()
 
 // encode the file paths for any + in the filename, e.g. apStar
 const urienc = props.files.map(encodeURIComponent)
-let url = ref(import.meta.env.VITE_API_URL + `/solara/embed/?release=${store.release}&sdssid=${props.sdssid}&files=${urienc.join()}&theme=${theme.global.name.value}`)
+const urifirst = encodeURIComponent(props.first)
+let url = ref(import.meta.env.VITE_API_URL + `/solara/embed/?release=${store.release}&sdssid=${props.sdssid}&files=${urifirst}&theme=${theme.global.name.value}`)
 console.log('url', url)
+
+// set target origin for postMessages
+const targetOrigin = new URL(url.value).origin
 
 async function check_solara() {
 
-    await axios.get(import.meta.env.VITE_API_URL + '/solara/embed/', {withCredentials: true})
+    await axios.get(import.meta.env.VITE_API_URL + '/solara/readyz', {withCredentials: true})
         .then((response) => {
             console.log('solara response', response)
             valid.value = true
@@ -61,9 +66,34 @@ watch(() => theme.global.name.value, (newVal) => {
     console.log('theme change', newVal)
     // watch for theme changes and send request
     if (iframe.value && iframe.value.contentWindow) {
-        iframe.value.contentWindow.postMessage({type: 'themeChange', theme: newVal}, '*')
+        iframe.value.contentWindow.postMessage({type: 'themeChange', theme: newVal}, targetOrigin)
+
     }
 })
+
+function postFiles() {
+    // post the files to the solara server
+    if (props.files && iframe.value && iframe.value.contentWindow) {
+        const files = props.files.map((f) => String(f))
+        iframe.value.contentWindow.postMessage({type: 'updateFiles', files: files}, targetOrigin)
+    }
+}
+
+window.addEventListener('message', (event) => {
+    // event listener from the solara backend
+
+    if (event.origin !== targetOrigin) {
+        console.warn('Received message from unknown origin:', event.origin)
+        return
+    }
+    console.log('Received message from Solara iframe:', event.data)
+
+    // backend has initialized enough to message parent; send files now
+    if (event.data === 'ready') {
+        postFiles()
+    }
+})
+
 
 onMounted(() => {
     // check the solara server

--- a/src/views/Target.vue
+++ b/src/views/Target.vue
@@ -264,7 +264,7 @@
                 <v-skeleton-loader v-if="loading" type="card"></v-skeleton-loader>
                 <v-banner v-else-if="!store.is_allowed()" type="warning" class='ma-4' color="warning" lines="one" icon="mdi-emoticon-confused"><v-banner-text>User not allowed to access spectra data.</v-banner-text></v-banner>
                 <v-banner v-else-if="!has_files" type="warning" class='ma-4' color="warning" lines="one" icon="mdi-emoticon-cry"><v-banner-text>No spectral data available to load.</v-banner-text></v-banner>
-                <Solara v-else :sdssid="sdss_id" :files="files"></Solara>
+                <Solara v-else :sdssid="sdss_id" :files="files" :first="first"></Solara>
             </v-col>
         </v-row>
 
@@ -313,6 +313,7 @@ let pipepanels = ref(null)
 let apopanels = ref([0])
 let astrapanels = ref([0])
 let files = ref([])
+let first = ref('')
 let has_files = ref(false)
 
 let head = [
@@ -461,7 +462,8 @@ async function get_target_info() {
         .filter(filePath => filePath && filePath.trim() !== '');
       // add files from legacy data
       files.value.push.apply(files.value, legacy.map(x => x.filepath) );
-      console.log('files', files.value, files.value.length)
+      first.value = pipes.files.astra?.[0] ?? pipes.files.boss?.[0] ?? pipes.files.apogee?.[0];
+      console.log('files', files.value, files.value.length, first.value)
       has_files.value = check_files(files.value)
       console.log('has_files', has_files.value)
       console.timeEnd('Info Time')


### PR DESCRIPTION
This PR is related to https://github.com/sdss/sdss_solara/pull/16. It now only sends the first file found, in order of astra, boss, apogee, as an input query parameter.  The remaining files are sent as an iframe postMessage to the solara backend, which updates the data selector.  